### PR TITLE
Fix match timestamps of events that happened while it was paused

### DIFF
--- a/src/Service/ReplaySummaryService.php
+++ b/src/Service/ReplaySummaryService.php
@@ -502,7 +502,7 @@ class ReplaySummaryService
     /**
      * @param IMatchTimeEvent $event
      *
-     * @return string
+     * @return MatchTime
      */
     private function calculateMatchTime(IMatchTimeEvent $event): MatchTime
     {


### PR DESCRIPTION
The problem was that I was calculating the "match time" of an event always with respect to the "offset start time," even while it was paused meaning these timestamps were calculated as if the match wasn't actually stopped.

Because this is a bug in the import process, replay files will need to be upgraded :slightly_frowning_face: I've added a new "--filenames" option to the import command to specify which files from a directory to import only. This is necessary to avoid having to "upgrade" my ~8700 replays.

To get a list of affected replays, you can use the following SQL query to get a list of replays that have pause events, and therefore, are likely affected by this bug.

```sql
SELECT
  file_name 
FROM
  replay
WHERE
  id IN (
    SELECT DISTINCT replay_id FROM pause_event
  )
```

Fixes #13 