### PR TITLE
Add ability to categorize maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ public/generated/
 npm-debug.log
 yarn-error.log
 ###< symfony/webpack-encore-bundle ###
+
+###> friendsofphp/php-cs-fixer ###
+/.php_cs
+/.php_cs.cache
+###< friendsofphp/php-cs-fixer ###

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -62,6 +62,7 @@ return PhpCsFixer\Config::create()
             'suffix' => '',
         ],
         PhpCsFixerCustomFixers\Fixer\MultilineCommentOpeningClosingAloneFixer::name() => true,
+        PhpCsFixerCustomFixers\Fixer\NoCommentedOutCodeFixer::name() => true,
         PhpCsFixerCustomFixers\Fixer\NoDoctrineMigrationsGeneratedCommentFixer::name() => true,
         PhpCsFixerCustomFixers\Fixer\NoImportFromGlobalNamespaceFixer::name() => true,
         PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer::name() => true,

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,6 +14,7 @@ LICENSE.md file that was distributed with this source code.
 HEADER;
 
 return PhpCsFixer\Config::create()
+    ->registerCustomFixers(new PhpCsFixerCustomFixers\Fixers())
     ->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,
@@ -56,6 +57,19 @@ return PhpCsFixer\Config::create()
             'equal' => false,
             'identical' => false,
         ],
+        PhpCsFixerCustomFixers\Fixer\DataProviderNameFixer::name() => [
+            'prefix' => 'dataProvider_test',
+            'suffix' => '',
+        ],
+        PhpCsFixerCustomFixers\Fixer\MultilineCommentOpeningClosingAloneFixer::name() => true,
+        PhpCsFixerCustomFixers\Fixer\NoDoctrineMigrationsGeneratedCommentFixer::name() => true,
+        PhpCsFixerCustomFixers\Fixer\NoImportFromGlobalNamespaceFixer::name() => true,
+        PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer::name() => true,
+        PhpCsFixerCustomFixers\Fixer\NoUselessDoctrineRepositoryCommentFixer::name() => true,
+        PhpCsFixerCustomFixers\Fixer\NoUselessStrlenFixer::name() => true,
+        PhpCsFixerCustomFixers\Fixer\PhpdocNoIncorrectVarAnnotationFixer::name() => true,
+        PhpCsFixerCustomFixers\Fixer\PhpdocSingleLineVarFixer::name() => true,
+        PhpCsFixerCustomFixers\Fixer\PhpdocTypesTrimFixer::name() => true,
     ])
     ->setFinder($finder)
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-    - "7.4snapshot"
+    - "7.4"
     - "7.3"
     - "7.2"
 
@@ -11,7 +11,7 @@ install:
     - composer install --no-interaction --no-progress
 
 script:
-    - bin/phpunit
+    - composer test
 
 notifications:
     email: false

--- a/assets/sass/app.scss
+++ b/assets/sass/app.scss
@@ -4,6 +4,7 @@
 
 @import 'component/flag-cap-timeline';
 @import 'component/graphs';
+@import 'component/map-card';
 @import 'component/map-thumbnail';
 @import 'component/replay-summary';
 @import 'component/score-card';

--- a/assets/sass/component/_map-card.scss
+++ b/assets/sass/component/_map-card.scss
@@ -1,0 +1,42 @@
+.map-card {
+    border: $border-default;
+}
+
+.map-card__no-preview {
+    margin-bottom: 0;
+    padding-bottom: 100%;
+    position: relative;
+    width: 100%;
+
+    span {
+        position: absolute;
+        text-align: center;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+    }
+}
+
+.map-card__title {
+    @include padding(x, 3);
+    @include padding(y, 2);
+
+    align-items: center;
+    border-top: $border-default;
+    display: flex;
+}
+
+.map-card__title__count,
+.map-card__title__name {
+    margin-bottom: 0;
+}
+
+.map-card__title__name {
+}
+
+.map-card__title__count {
+    @include font-size(h5);
+
+    flex-grow: 1;
+    text-align: right;
+}

--- a/assets/sass/component/_map-thumbnail.scss
+++ b/assets/sass/component/_map-thumbnail.scss
@@ -1,4 +1,5 @@
 .map-thumbnail {
     display: block;
+    margin: 0 auto;
     max-width: 100%;
 }

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "symfony/process": "^4.0",
         "symfony/security-bundle": "^4.0",
         "symfony/serializer-pack": "*",
+        "symfony/string": "^5.1",
         "symfony/swiftmailer-bundle": "^3.1",
         "symfony/translation": "^4.0",
         "symfony/twig-bundle": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
         "symfony/yaml": "^4.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.16",
+        "kubawerlos/php-cs-fixer-custom-fixers": "^2.3",
+        "phpstan/phpstan": "^0.12.37",
         "symfony/debug-pack": "*",
         "symfony/maker-bundle": "^1.0",
         "symfony/profiler-pack": "*",
@@ -77,7 +80,9 @@
         ],
         "post-update-cmd": [
             "@auto-scripts"
-        ]
+        ],
+        "fix": "php-cs-fixer fix",
+        "test": "simple-phpunit"
     },
     "conflict": {
         "symfony/symfony": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f56b861bd067a0dee72c3c56d66dc8a6",
+    "content-hash": "3f507d29f60eb79ee5225463ec9ff2c3",
     "packages": [
         {
             "name": "allejo/bzflag-networking.php",
@@ -4608,6 +4608,84 @@
             "time": "2020-02-10T18:03:48+00:00"
         },
         {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.18.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "b740103edbdcc39602239ee8860f0f45a8eb9aa5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b740103edbdcc39602239ee8860f0f45a8eb9aa5",
+                "reference": "b740103edbdcc39602239ee8860f0f45a8eb9aa5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-14T12:35:20+00:00"
+        },
+        {
             "name": "symfony/polyfill-intl-icu",
             "version": "v1.18.1",
             "source": {
@@ -6165,6 +6243,91 @@
             "time": "2020-05-20T08:37:50+00:00"
         },
         {
+            "name": "symfony/string",
+            "version": "v5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "f629ba9b611c76224feb21fe2bcbf0b6f992300b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f629ba9b611c76224feb21fe2bcbf0b6f992300b",
+                "reference": "f629ba9b611c76224feb21fe2bcbf0b6f992300b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "~1.15"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony String component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-08T08:27:49+00:00"
+        },
+        {
             "name": "symfony/swiftmailer-bundle",
             "version": "v3.4.0",
             "source": {
@@ -7325,6 +7488,265 @@
     ],
     "packages-dev": [
         {
+            "name": "composer/semver",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
+                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2020-01-13T12:06:48+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51",
+                "reference": "fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-04T11:16:35+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v2.16.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "1023c3458137ab052f6ff1e09621a721bfdeca13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/1023c3458137ab052f6ff1e09621a721bfdeca13",
+                "reference": "1023c3458137ab052f6ff1e09621a721bfdeca13",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^1.4",
+                "composer/xdebug-handler": "^1.2",
+                "doctrine/annotations": "^1.2",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": "^5.6 || ^7.0",
+                "php-cs-fixer/diff": "^1.3",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
+                "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
+                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
+                "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0",
+                "symfony/polyfill-php70": "^1.0",
+                "symfony/polyfill-php72": "^1.4",
+                "symfony/process": "^3.0 || ^4.0 || ^5.0",
+                "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
+                "justinrainbow/json-schema": "^5.0",
+                "keradus/cli-executor": "^1.2",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.1",
+                "php-cs-fixer/accessible-object": "^1.0",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.1",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
+                "phpunitgoodpractices/traits": "^1.8",
+                "symfony/phpunit-bridge": "^5.1",
+                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters.",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
+                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "classmap": [
+                    "tests/Test/AbstractFixerTestCase.php",
+                    "tests/Test/AbstractIntegrationCaseFactory.php",
+                    "tests/Test/AbstractIntegrationTestCase.php",
+                    "tests/Test/Assert/AssertTokensTrait.php",
+                    "tests/Test/IntegrationCase.php",
+                    "tests/Test/IntegrationCaseFactory.php",
+                    "tests/Test/IntegrationCaseFactoryInterface.php",
+                    "tests/Test/InternalIntegrationCaseFactory.php",
+                    "tests/Test/IsIdenticalConstraint.php",
+                    "tests/TestCase.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-06-27T23:57:46+00:00"
+        },
+        {
+            "name": "kubawerlos/php-cs-fixer-custom-fixers",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers.git",
+                "reference": "ba15f63415679a2f97a93d2da0b1788b95596d52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/ba15f63415679a2f97a93d2da0b1788b95596d52",
+                "reference": "ba15f63415679a2f97a93d2da0b1788b95596d52",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "friendsofphp/php-cs-fixer": "^2.16.4",
+                "php": "^7.2",
+                "symfony/finder": "^3.0 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "johnkary/phpunit-speedtrap": "^3.2.0",
+                "phpunit/phpunit": "^8.5.3 || ^9.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixerCustomFixers\\": "./src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kuba Werłos",
+                    "email": "werlos@gmail.com"
+                }
+            ],
+            "description": "A set of custom fixers for PHP CS Fixer",
+            "time": "2020-07-07T21:00:32+00:00"
+        },
+        {
             "name": "nikic/php-parser",
             "version": "v4.8.0",
             "source": {
@@ -7375,6 +7797,113 @@
                 "php"
             ],
             "time": "2020-08-09T10:23:20+00:00"
+        },
+        {
+            "name": "php-cs-fixer/diff",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/diff.git",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "symfony/process": "^3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "SpacePossum"
+                }
+            ],
+            "description": "sebastian/diff v2 backport support for PHP5.6",
+            "homepage": "https://github.com/PHP-CS-Fixer",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2018-02-15T16:58:55+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "0.12.37",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "5e16d83e6eb2dd784fbdaeaece5e2bca72e4f68a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/5e16d83e6eb2dd784fbdaeaece5e2bca72e4f68a",
+                "reference": "5e16d83e6eb2dd784fbdaeaece5e2bca72e4f68a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.12-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-09T14:32:41+00:00"
         },
         {
             "name": "symfony/browser-kit",

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -26,6 +26,8 @@ doctrine:
         dql:
             datetime_functions:
                 date_format: DoctrineExtensions\Query\Mysql\DateFormat
+            string_functions:
+                any_value: DoctrineExtensions\Query\Mysql\AnyValue
         mappings:
             App:
                 is_bundle: false

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "babel-plugin-jsx-to-dom": "^0.6.1",
         "babel-plugin-syntax-jsx": "^6.18.0",
         "sass": "^1.20.1",
-        "sass-loader": "^7.1.0",
+        "sass-loader": "^8.0.0",
         "webpack-notifier": "^1.6.0"
     },
     "license": "MIT",

--- a/src/Command/MapAssociateCommand.php
+++ b/src/Command/MapAssociateCommand.php
@@ -1,0 +1,133 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace App\Command;
+
+use App\Entity\KnownMap;
+use App\Entity\MapThumbnail;
+use App\Entity\Replay;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class MapAssociateCommand extends Command
+{
+    protected static $defaultName = 'app:map:associate';
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+
+        $this->entityManager = $entityManager;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Associate a map hash with a known map in the database')
+            ->addOption('to-map-slug', null, InputOption::VALUE_OPTIONAL, '')
+            ->addOption('to-map-id', null, InputOption::VALUE_OPTIONAL, '')
+            ->addOption('from-replay-id', null, InputOption::VALUE_OPTIONAL, '')
+            ->addOption('from-hash', null, InputOption::VALUE_OPTIONAL, '')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $knownMap = $this->getKnownMap($input, $io);
+
+        $thumbnail = $this->getMapThumbnail($input, $io);
+        $thumbnail->setKnownMap($knownMap);
+
+        $this->entityManager->persist($thumbnail);
+        $this->entityManager->flush();
+
+        $io->writeln('Done!');
+
+        return 0;
+    }
+
+    private function getKnownMap(InputInterface $input, SymfonyStyle $io): KnownMap
+    {
+        $knownMapRepo = $this->entityManager->getRepository(KnownMap::class);
+
+        if (($knownMapId = $input->getOption('to-map-id')) !== null) {
+            $knownMap = $knownMapRepo->find($knownMapId);
+
+            if ($knownMap) {
+                return $knownMap;
+            }
+        }
+
+        if (($mapSlug = $input->getOption('to-map-slug')) !== null) {
+            $knownMap = $knownMapRepo->findOneBy(['slug' => $mapSlug]);
+
+            if ($knownMap) {
+                return $knownMap;
+            }
+        }
+
+        $maps = $knownMapRepo->findAll();
+        $mapNames = array_map(static function ($map) { return $map->getName(); }, $maps);
+
+        while (true) {
+            $helper = new Question('Please enter map name');
+            $helper->setAutocompleterValues($mapNames);
+
+            $mapInput = $io->askQuestion($helper);
+
+            if (($knownMap = $knownMapRepo->findOneBy(['name' => $mapInput])) !== null) {
+                return $knownMap;
+            }
+        }
+    }
+
+    private function getMapThumbnail(InputInterface $input, SymfonyStyle $io): MapThumbnail
+    {
+        $replayRepo = $this->entityManager->getRepository(Replay::class);
+        $thumbnailRepo = $this->entityManager->getRepository(MapThumbnail::class);
+
+        if (($hashInput = $input->getOption('from-hash')) !== null) {
+            $mapThumbnail = $thumbnailRepo->findBy([
+                'worldHash' => $hashInput,
+            ], null, 1);
+
+            if ($mapThumbnail !== null && count($mapThumbnail) === 1) {
+                return $mapThumbnail[0];
+            }
+        }
+
+        if (($replayID = $input->getOption('from-replay-id')) !== null) {
+            $replay = $replayRepo->find($replayID);
+
+            if ($replay && $replay->getMapThumbnail()) {
+                return $replay->getMapThumbnail();
+            }
+        }
+
+        while (true) {
+            $hashInput = $io->ask('Please enter world database hash');
+            $mapThumbnail = $thumbnailRepo->findBy([
+                'worldHash' => $hashInput,
+            ], null, 1);
+
+            if ($mapThumbnail !== null && count($mapThumbnail) === 1) {
+                return $mapThumbnail[0];
+            }
+        }
+    }
+}

--- a/src/Command/MapCreateCommand.php
+++ b/src/Command/MapCreateCommand.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace App\Command;
+
+use App\Entity\KnownMap;
+use App\Repository\KnownMapRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+class MapCreateCommand extends Command
+{
+    protected static $defaultName = 'app:map:create';
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+
+        $this->entityManager = $entityManager;
+    }
+
+    protected function configure()
+    {
+        $desc = <<<DESC
+Create a new known map definition
+
+A known map definition is useful for associating map thumbnails with human-
+readable names that can be used in searches.
+DESC;
+
+        $this
+            ->setDescription($desc)
+            ->addArgument('mapName', InputArgument::OPTIONAL, 'The human-readable map name used for this map')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $mapName = $input->getArgument('mapName');
+
+        if (!$mapName) {
+            $question = new Question('Name of the map to create');
+            $mapName = $io->askQuestion($question);
+        }
+
+        /** @var KnownMapRepository $knownMapRepo */
+        $knownMapRepo = $this->entityManager->getRepository(KnownMap::class);
+        $slugger = new AsciiSlugger();
+        $slug = strtolower($slugger->slug($mapName)->toString());
+
+        $existingMap = $knownMapRepo->findOneBy(compact('slug'));
+
+        if ($existingMap !== null) {
+            $io->error(strtr('A map with the name of "{mapName}" already exists.', ['{mapName}' => $mapName]));
+
+            return 1;
+        }
+
+        $newMap = new KnownMap();
+        $newMap->setName($mapName);
+        $newMap->setSlug($slug);
+
+        $this->entityManager->persist($newMap);
+        $this->entityManager->flush();
+
+        $io->success(strtr('You have created a new map by the name of "{mapName}".', ['{mapName}' => $mapName]));
+
+        return 0;
+    }
+}

--- a/src/Command/MapListCommand.php
+++ b/src/Command/MapListCommand.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace App\Command;
+
+use App\Entity\KnownMap;
+use App\Repository\KnownMapRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MapListCommand extends Command
+{
+    protected static $defaultName = 'app:map:list';
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+
+        $this->entityManager = $entityManager;
+    }
+
+    protected function configure()
+    {
+        $desc = <<<DESC
+List all of the known maps
+
+In addition to listing the maps, this also displays how many definitions each
+map has.
+DESC;
+
+        $this
+            ->setDescription($desc)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var KnownMapRepository $knownMapRepo */
+        $knownMapRepo = $this->entityManager->getRepository(KnownMap::class);
+        $maps = $knownMapRepo->findAll();
+        $rows = [];
+
+        foreach ($maps as $map) {
+            $rows[] = [
+                $map->getId(),
+                $map->getName(),
+                $map->getSlug(),
+                0,
+            ];
+        }
+
+        $table = new Table($output);
+        $table
+            ->setHeaders(['ID', 'Map Name', 'Slug', 'Count'])
+            ->setRows($rows)
+        ;
+        $table->render();
+
+        return 0;
+    }
+}

--- a/src/Command/ReplayDeleteCommand.php
+++ b/src/Command/ReplayDeleteCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
-class DeleteReplayCommand extends Command
+class ReplayDeleteCommand extends Command
 {
     protected static $defaultName = 'app:replay:delete';
 

--- a/src/Command/ReplayImportCommand.php
+++ b/src/Command/ReplayImportCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 
-class ImportReplayCommand extends Command
+class ReplayImportCommand extends Command
 {
     protected static $defaultName = 'app:replay:import';
 

--- a/src/Controller/ApiV1Controller.php
+++ b/src/Controller/ApiV1Controller.php
@@ -9,6 +9,7 @@
 
 namespace App\Controller;
 
+use App\Entity\KnownMap;
 use App\Entity\Replay;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -20,13 +21,16 @@ use Symfony\Component\Routing\Annotation\Route;
 class ApiV1Controller extends AbstractController
 {
     /**
-     * @Route("/summarize/replays", name="api_summary_replays")
+     * @Route("/summarize/replays/{map}", name="api_summary_replays")
      */
-    public function replayCountAction()
+    public function replayCountAction(?KnownMap $map = null)
     {
-        $em = $this->getDoctrine()->getManager();
-
-        $summary_count = $em->getRepository(Replay::class)->getSummaryCount();
+        $summary_count = $this
+            ->getDoctrine()
+            ->getManager()
+            ->getRepository(Replay::class)
+            ->getSummaryCount(null, null, $map)
+        ;
 
         return new JsonResponse($this->renderTimeSeriesGraph(
             'match_date',

--- a/src/Controller/MapController.php
+++ b/src/Controller/MapController.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use App\Entity\KnownMap;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+class MapController extends AbstractController
+{
+    /**
+     * @Route("/maps", name="map_list")
+     */
+    public function index()
+    {
+        $em = $this->getDoctrine()->getManager();
+        $mapRepo = $em->getRepository(KnownMap::class);
+
+        return $this->render('map/index.html.twig', [
+            'maps' => $mapRepo->findAll(),
+            'map_counts' => $mapRepo->findUsageCounts(),
+            'map_thumbnails' => $mapRepo->findThumbnails(),
+        ]);
+    }
+}

--- a/src/Controller/MapController.php
+++ b/src/Controller/MapController.php
@@ -41,7 +41,7 @@ class MapController extends AbstractController
     {
         $em = $this->getDoctrine()->getManager();
         $replayRepo = $em->getRepository(Replay::class);
-        $replays = $replayRepo->findByMap($map, 15);
+        $replays = $replayRepo->findByMap($map, 14);
         $summaries = QuickReplaySummary::summarizeReplays($summaryService, $replays, null);
 
         return $this->render('map/show.html.twig', [

--- a/src/Controller/ReplayController.php
+++ b/src/Controller/ReplayController.php
@@ -111,16 +111,7 @@ class ReplayController extends AbstractController
         }
 
         $summaryService->summarizeFull($replay);
-
         $thumbnail = $replay->getMapThumbnail();
-        $thumbnailURL = null;
-
-        if ($thumbnail !== null) {
-            $thumbnailURL = vsprintf('generated/%s/%s.svg', [
-                MapThumbnailWriterService::FOLDER_NAME,
-                $thumbnail->getWorldHash(),
-            ]);
-        }
 
         $replayMap = null;
 
@@ -133,7 +124,7 @@ class ReplayController extends AbstractController
                 'id' => $replay->getId(),
                 'filename' => $replay->getFileName(),
                 'map' => $replayMap,
-                'thumbnailURL' => $thumbnailURL,
+                'thumbnail' => $thumbnail,
                 'start' => $replay->getStartTime(),
                 'end' => $replay->getEndTime(),
                 'duration' => $summaryService->getDuration(),

--- a/src/Entity/KnownMap.php
+++ b/src/Entity/KnownMap.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace App\Entity;
+
+use App\Repository\KnownMapRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass=KnownMapRepository::class)
+ */
+class KnownMap
+{
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=32)
+     */
+    private $name;
+
+    /**
+     * @ORM\Column(type="string", length=32)
+     */
+    private $slug;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): self
+    {
+        $this->slug = $slug;
+
+        return $this;
+    }
+}

--- a/src/Entity/MapThumbnail.php
+++ b/src/Entity/MapThumbnail.php
@@ -32,14 +32,14 @@ class MapThumbnail
     private $worldHash;
 
     /**
-     * @ORM\Column(type="string", length=255)
-     */
-    private $filename;
-
-    /**
      * @ORM\OneToMany(targetEntity=Replay::class, mappedBy="mapThumbnail")
      */
     private $replays;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=KnownMap::class)
+     */
+    private $knownMap;
 
     public function __construct()
     {
@@ -59,18 +59,6 @@ class MapThumbnail
     public function setWorldHash(string $worldHash): self
     {
         $this->worldHash = $worldHash;
-
-        return $this;
-    }
-
-    public function getFilename(): ?string
-    {
-        return $this->filename;
-    }
-
-    public function setFilename(string $filename): self
-    {
-        $this->filename = $filename;
 
         return $this;
     }
@@ -102,6 +90,18 @@ class MapThumbnail
                 $replay->setMapThumbnail(null);
             }
         }
+
+        return $this;
+    }
+
+    public function getKnownMap(): ?KnownMap
+    {
+        return $this->knownMap;
+    }
+
+    public function setKnownMap(?KnownMap $knownMap): self
+    {
+        $this->knownMap = $knownMap;
 
         return $this;
     }

--- a/src/Event/ExistingThumbnailUsedEvent.php
+++ b/src/Event/ExistingThumbnailUsedEvent.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace App\Event;
+
+use allejo\bzflag\world\WorldDatabase;
+use App\Entity\MapThumbnail;
+use App\Entity\Replay;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class ExistingThumbnailUsedEvent extends Event
+{
+    /** @var WorldDatabase */
+    private $worldDatabase;
+
+    /** @var MapThumbnail */
+    private $mapThumbnail;
+
+    /** @var Replay */
+    private $replay;
+
+    /** @var bool */
+    private $causedByRegeneration;
+
+    public function __construct(WorldDatabase $worldDatabase, MapThumbnail $mapThumbnail, Replay $replay, bool $causedByRegeneration)
+    {
+        $this->worldDatabase = $worldDatabase;
+        $this->mapThumbnail = $mapThumbnail;
+        $this->replay = $replay;
+        $this->causedByRegeneration = $causedByRegeneration;
+    }
+
+    public function isCausedByRegeneration(): bool
+    {
+        return $this->causedByRegeneration;
+    }
+
+    public function getReplay(): Replay
+    {
+        return $this->replay;
+    }
+
+    public function getWorldDatabase(): WorldDatabase
+    {
+        return $this->worldDatabase;
+    }
+
+    public function getMapThumbnail(): MapThumbnail
+    {
+        return $this->mapThumbnail;
+    }
+}

--- a/src/Event/NewMapThumbnailGeneratedEvent.php
+++ b/src/Event/NewMapThumbnailGeneratedEvent.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace App\Event;
+
+use allejo\bzflag\world\WorldDatabase;
+use App\Entity\MapThumbnail;
+use App\Entity\Replay;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class NewMapThumbnailGeneratedEvent extends Event
+{
+    /** @var WorldDatabase */
+    private $worldDatabase;
+
+    /** @var MapThumbnail */
+    private $mapThumbnail;
+
+    /** @var Replay */
+    private $replay;
+
+    public function __construct(WorldDatabase $worldDatabase, MapThumbnail $mapThumbnail, Replay $replay)
+    {
+        $this->worldDatabase = $worldDatabase;
+        $this->mapThumbnail = $mapThumbnail;
+        $this->replay = $replay;
+    }
+
+    public function getReplay(): Replay
+    {
+        return $this->replay;
+    }
+
+    public function getWorldDatabase(): WorldDatabase
+    {
+        return $this->worldDatabase;
+    }
+
+    public function getMapThumbnail(): MapThumbnail
+    {
+        return $this->mapThumbnail;
+    }
+}

--- a/src/EventSubscriber/DucatiThumbnailMatcherSubscriber.php
+++ b/src/EventSubscriber/DucatiThumbnailMatcherSubscriber.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace App\EventSubscriber;
+
+use allejo\bzflag\world\WorldDatabase;
+use App\Entity\KnownMap;
+use App\Entity\MapThumbnail;
+use App\Event\ExistingThumbnailUsedEvent;
+use App\Event\NewMapThumbnailGeneratedEvent;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class DucatiThumbnailMatcherSubscriber implements EventSubscriberInterface
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function onExistingThumbnailSelected(ExistingThumbnailUsedEvent $event): void
+    {
+        $thumbnail = $event->getMapThumbnail();
+
+        if ($thumbnail && $thumbnail->getKnownMap() !== null) {
+            return;
+        }
+
+        $this->applyDucatiClassification($thumbnail, $event->getWorldDatabase());
+    }
+
+    public function onNewThumbnailGeneratedSelected(NewMapThumbnailGeneratedEvent $event): void
+    {
+        $thumbnail = $event->getMapThumbnail();
+
+        if (!$thumbnail) {
+            return;
+        }
+
+        $this->applyDucatiClassification($thumbnail, $event->getWorldDatabase());
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ExistingThumbnailUsedEvent::class => 'onExistingThumbnailSelected',
+            NewMapThumbnailGeneratedEvent::class => 'onNewThumbnailGeneratedSelected',
+        ];
+    }
+
+    private function applyDucatiClassification(MapThumbnail $thumbnail, WorldDatabase $worldDatabase): void
+    {
+        $worldSize = (int)$worldDatabase->getBZDBManager()->getBZDBVariable('_worldSize');
+
+        if ($worldSize === 600) {
+            if (($map = $this->getDucatiMini()) !== null) {
+                $thumbnail->setKnownMap($map);
+            }
+        } elseif ($worldSize === 800) {
+            if (($map = $this->getDucati()) !== null) {
+                $thumbnail->setKnownMap($map);
+            }
+        }
+    }
+
+    private function getDucati(): ?KnownMap
+    {
+        return $this->entityManager
+            ->getRepository(KnownMap::class)
+            ->findOneBy([
+                'name' => 'Ducati',
+            ])
+        ;
+    }
+
+    private function getDucatiMini(): ?KnownMap
+    {
+        return $this->entityManager
+            ->getRepository(KnownMap::class)
+            ->findOneBy([
+                'name' => 'Ducati Mini',
+            ])
+        ;
+    }
+}

--- a/src/Migrations/Version20190518223750.php
+++ b/src/Migrations/Version20190518223750.php
@@ -14,9 +14,6 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version20190518223750 extends AbstractMigration
 {
     public function getDescription(): string
@@ -26,7 +23,6 @@ final class Version20190518223750 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('CREATE TABLE capture_event (id INT AUTO_INCREMENT NOT NULL, replay_id INT NOT NULL, capper_id INT NOT NULL, capper_team INT NOT NULL, capped_team INT NOT NULL, timestamp DATETIME NOT NULL, INDEX IDX_83A193C9186CE3E1 (replay_id), INDEX IDX_83A193C971085808 (capper_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
@@ -57,7 +53,6 @@ final class Version20190518223750 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE part_event DROP FOREIGN KEY FK_A8DD5D443C972CB8');

--- a/src/Migrations/Version20190527085129.php
+++ b/src/Migrations/Version20190527085129.php
@@ -14,9 +14,6 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version20190527085129 extends AbstractMigration
 {
     public function getDescription(): string
@@ -26,7 +23,6 @@ final class Version20190527085129 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('CREATE TABLE pause_event (id INT AUTO_INCREMENT NOT NULL, replay_id INT NOT NULL, timestamp DATETIME NOT NULL, INDEX IDX_EAB1B862186CE3E1 (replay_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
@@ -37,7 +33,6 @@ final class Version20190527085129 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('DROP TABLE pause_event');

--- a/src/Migrations/Version20190527085955.php
+++ b/src/Migrations/Version20190527085955.php
@@ -14,9 +14,6 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version20190527085955 extends AbstractMigration
 {
     public function getDescription(): string
@@ -26,7 +23,6 @@ final class Version20190527085955 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE replay ADD file_hash VARCHAR(40) DEFAULT NULL');
@@ -34,7 +30,6 @@ final class Version20190527085955 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE replay DROP file_hash');

--- a/src/Migrations/Version20190527091907.php
+++ b/src/Migrations/Version20190527091907.php
@@ -14,9 +14,6 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version20190527091907 extends AbstractMigration
 {
     public function getDescription(): string
@@ -26,7 +23,6 @@ final class Version20190527091907 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE capture_event ADD match_seconds INT DEFAULT NULL');
@@ -41,7 +37,6 @@ final class Version20190527091907 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE capture_event DROP match_seconds');

--- a/src/Migrations/Version20190609054827.php
+++ b/src/Migrations/Version20190609054827.php
@@ -14,9 +14,6 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version20190609054827 extends AbstractMigration
 {
     public function getDescription(): string
@@ -26,7 +23,6 @@ final class Version20190609054827 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE capture_event DROP FOREIGN KEY FK_83A193C9186CE3E1');
@@ -63,7 +59,6 @@ final class Version20190609054827 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE capture_event DROP FOREIGN KEY FK_83A193C9186CE3E1');

--- a/src/Migrations/Version20190621063906.php
+++ b/src/Migrations/Version20190621063906.php
@@ -14,9 +14,6 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version20190621063906 extends AbstractMigration
 {
     public function getDescription(): string
@@ -26,7 +23,6 @@ final class Version20190621063906 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE replay ADD canceled TINYINT(1) DEFAULT \'0\'');
@@ -34,7 +30,6 @@ final class Version20190621063906 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE replay DROP canceled');

--- a/src/Migrations/Version20200602050954.php
+++ b/src/Migrations/Version20200602050954.php
@@ -14,9 +14,6 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version20200602050954 extends AbstractMigration
 {
     public function getDescription(): string
@@ -26,7 +23,6 @@ final class Version20200602050954 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('CREATE TABLE map_thumbnail (id INT AUTO_INCREMENT NOT NULL, world_hash VARCHAR(40) NOT NULL, filename VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
@@ -37,7 +33,6 @@ final class Version20200602050954 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE replay DROP FOREIGN KEY FK_D937F4F265CAA37C');

--- a/src/Migrations/Version20200815230755.php
+++ b/src/Migrations/Version20200815230755.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20200815230755 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE known_map (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(32) NOT NULL, slug VARCHAR(32) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE map_thumbnail ADD known_map_id INT DEFAULT NULL, DROP filename');
+        $this->addSql('ALTER TABLE map_thumbnail ADD CONSTRAINT FK_663F61BB666297A6 FOREIGN KEY (known_map_id) REFERENCES known_map (id)');
+        $this->addSql('CREATE INDEX IDX_663F61BB666297A6 ON map_thumbnail (known_map_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE map_thumbnail DROP FOREIGN KEY FK_663F61BB666297A6');
+        $this->addSql('DROP TABLE known_map');
+        $this->addSql('DROP INDEX IDX_663F61BB666297A6 ON map_thumbnail');
+        $this->addSql('ALTER TABLE map_thumbnail ADD filename VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci`, DROP known_map_id');
+    }
+}

--- a/src/Repository/KnownMapRepository.php
+++ b/src/Repository/KnownMapRepository.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace App\Repository;
+
+use App\Entity\KnownMap;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
+
+/**
+ * @method KnownMap|null find($id, $lockMode = null, $lockVersion = null)
+ * @method KnownMap|null findOneBy(array $criteria, array $orderBy = null)
+ * @method KnownMap[]    findAll()
+ * @method KnownMap[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class KnownMapRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, KnownMap::class);
+    }
+}

--- a/src/Repository/MapThumbnailRepository.php
+++ b/src/Repository/MapThumbnailRepository.php
@@ -25,33 +25,4 @@ class MapThumbnailRepository extends ServiceEntityRepository
     {
         parent::__construct($registry, MapThumbnail::class);
     }
-
-    // /**
-    //  * @return MapThumbnail[] Returns an array of MapThumbnail objects
-    //  */
-    /*
-    public function findByExampleField($value)
-    {
-        return $this->createQueryBuilder('m')
-            ->andWhere('m.exampleField = :val')
-            ->setParameter('val', $value)
-            ->orderBy('m.id', 'ASC')
-            ->setMaxResults(10)
-            ->getQuery()
-            ->getResult()
-        ;
-    }
-    */
-
-    /*
-    public function findOneBySomeField($value): ?MapThumbnail
-    {
-        return $this->createQueryBuilder('m')
-            ->andWhere('m.exampleField = :val')
-            ->setParameter('val', $value)
-            ->getQuery()
-            ->getOneOrNullResult()
-        ;
-    }
-    */
 }

--- a/src/Repository/MapThumbnailRepository.php
+++ b/src/Repository/MapThumbnailRepository.php
@@ -9,6 +9,7 @@
 
 namespace App\Repository;
 
+use App\Entity\KnownMap;
 use App\Entity\MapThumbnail;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -24,5 +25,17 @@ class MapThumbnailRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, MapThumbnail::class);
+    }
+
+    public function findSingleThumbnailForMap(KnownMap $map): ?MapThumbnail
+    {
+        return $this->createQueryBuilder('t')
+            ->join('t.knownMap', 'm')
+            ->where('m = :map')
+            ->setMaxResults(1)
+            ->setParameter('map', $map)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
     }
 }

--- a/src/Repository/ReplayRepository.php
+++ b/src/Repository/ReplayRepository.php
@@ -10,7 +10,6 @@
 namespace App\Repository;
 
 use App\Entity\Replay;
-use DateTime;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\NonUniqueResultException;
@@ -59,7 +58,7 @@ class ReplayRepository extends ServiceEntityRepository
     /**
      * @return Replay[]
      */
-    public function findByTimeRange(?DateTime $after = null, ?DateTime $before = null): array
+    public function findByTimeRange(?\DateTime $after = null, ?\DateTime $before = null): array
     {
         $flipRequired = false;
         $qb = $this->createQueryBuilder('r');
@@ -96,10 +95,10 @@ class ReplayRepository extends ServiceEntityRepository
         return $result;
     }
 
-    public function getSummaryCount(?DateTime $start = null, ?DateTime $end = null)
+    public function getSummaryCount(?\DateTime $start = null, ?\DateTime $end = null)
     {
-        $end = $end ?? new DateTime('now');
-        $start = $start ?? (new DateTime('now'))->modify('-90 days');
+        $end = $end ?? new \DateTime('now');
+        $start = $start ?? (new \DateTime('now'))->modify('-90 days');
 
         $qb = $this->createQueryBuilder('r');
         $qb

--- a/src/Service/ReplaySummaryService.php
+++ b/src/Service/ReplaySummaryService.php
@@ -52,14 +52,14 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class ReplaySummaryService
 {
-    /** @var int Default state for this service, where nothing has been summarized. */
-    const UNSUMMARIZED = 0;
+    /** Default state for this service, where nothing has been summarized. */
+    public const UNSUMMARIZED = 0;
 
-    /** @var int This service has summarized a replay in a quick manner. */
-    const SUMMARIZED_QUICK = 10;
+    /** This service has summarized a replay in a quick manner. */
+    public const SUMMARIZED_QUICK = 10;
 
-    /** @var int This service has summarized a replay completely. */
-    const SUMMARIZED_FULL = 20;
+    /** This service has summarized a replay completely. */
+    public const SUMMARIZED_FULL = 20;
 
     /** @var EntityManagerInterface */
     private $em;

--- a/src/Twig/Exception/MissingExtensionException.php
+++ b/src/Twig/Exception/MissingExtensionException.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace App\Twig\Exception;
+
+class MissingExtensionException extends \Exception
+{
+}

--- a/src/Twig/MapThumbnailExtension.php
+++ b/src/Twig/MapThumbnailExtension.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace App\Twig;
+
+use App\Entity\MapThumbnail;
+use App\Service\MapThumbnailWriterService;
+use App\Twig\Exception\MissingExtensionException;
+use Symfony\Bridge\Twig\Extension\AssetExtension;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\Markup;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+class MapThumbnailExtension extends AbstractExtension
+{
+    /** @var Environment */
+    private $environment;
+
+    public function __construct(Environment $environment)
+    {
+        $this->environment = $environment;
+    }
+
+    /**
+     * @throws MissingExtensionException when a required Twig extension could
+     *                                   not be found in the current Twig environment
+     */
+    public function buildImgTag(MapThumbnail $thumbnail): Markup
+    {
+        $mapName = 'a map';
+        if ($thumbnail->getKnownMap()) {
+            $mapName = $thumbnail->getKnownMap()->getName();
+        }
+
+        if (!$this->environment->hasExtension(AssetExtension::class)) {
+            throw new MissingExtensionException('The `AssetExtension` is required for this extension');
+        }
+
+        /** @var AssetExtension $assetExtension */
+        $assetExtension = $this->environment->getExtension(AssetExtension::class);
+        $thumbnailURL = vsprintf('generated/%s/%s.svg', [
+            MapThumbnailWriterService::FOLDER_NAME,
+            $thumbnail->getWorldHash(),
+        ]);
+
+        $markup = <<<MARKUP
+            <img
+                class="map-thumbnail"
+                src="{$assetExtension->getAssetUrl($thumbnailURL)}"
+                alt="A bird's eye view of {$mapName}"
+                aria-hidden="true"
+            />
+MARKUP;
+
+        return new Markup($markup, 'UTF-8');
+    }
+
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('map_thumbnail', [$this, 'buildImgTag']),
+        ];
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('map_thumbnail', [$this, 'buildImgTag']),
+        ];
+    }
+}

--- a/src/Twig/NumberAbbreviation.php
+++ b/src/Twig/NumberAbbreviation.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace App\Twig;
+
+use Symfony\Component\Inflector\Inflector;
+use Twig\Extension\AbstractExtension;
+use Twig\Markup;
+use Twig\TwigFilter;
+
+class NumberAbbreviation extends AbstractExtension
+{
+    public function abbreviateNumber(int $number, int $precision = 1, ?string $noun = null, ?string $content = null): Markup
+    {
+        if ($number < 1000) {
+            return new Markup($number, 'UTF-8');
+        }
+
+        $abbr = '';
+        $divisor = 1;
+        $divisors = [
+            1000 ** 1 => 'K',  // Thousand
+            1000 ** 2 => 'M',  // Million
+            1000 ** 3 => 'B',  // Billion
+            1000 ** 4 => 'T',  // Trillion
+            1000 ** 5 => 'Qa', // Quadrillion
+            1000 ** 6 => 'Qi', // Quintillion
+        ];
+
+        // Loop through each $divisor and find the lowest amount that matches
+        foreach ($divisors as $divisor => $abbr) {
+            if (abs($number) < ($divisor * 1000)) {
+                break; // We found a match!
+            }
+        }
+
+        // We found our match, or there were no matches.
+        $value = number_format($number / $divisor, $precision) . $abbr;
+
+        // English setup
+        $nounUsed = '';
+        if ($noun !== null) {
+            $nounUsed = Inflector::pluralize($noun);
+        }
+
+        $title = trim(implode(' ', [number_format($number), $nounUsed, $content]));
+
+        return new Markup("<span title=\"{$title}\">{$value}</span>", 'UTF-8');
+    }
+
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('number_abbr', [$this, 'abbreviateNumber']),
+        ];
+    }
+}

--- a/src/Twig/NumberAbbreviationExtension.php
+++ b/src/Twig/NumberAbbreviationExtension.php
@@ -14,7 +14,7 @@ use Twig\Extension\AbstractExtension;
 use Twig\Markup;
 use Twig\TwigFilter;
 
-class NumberAbbreviation extends AbstractExtension
+class NumberAbbreviationExtension extends AbstractExtension
 {
     public function abbreviateNumber(int $number, int $precision = 1, ?string $noun = null, ?string $content = null): Markup
     {

--- a/src/Twig/TimeExtension.php
+++ b/src/Twig/TimeExtension.php
@@ -1,4 +1,11 @@
-<?php
+<?php declare(strict_types=1);
+
+/*
+ * (c) Vladimir "allejo" Jimenez <me@allejo.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
 
 namespace App\Twig;
 

--- a/src/Twig/TimeExtension.php
+++ b/src/Twig/TimeExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Twig;
+
+use App\Utility\DateTimeFormatTranslator;
+use Twig\Extension\AbstractExtension;
+use Twig\Markup;
+use Twig\TwigFilter;
+
+class TimeExtension extends AbstractExtension
+{
+    public function buildTimeTag(\DateTime $dateTime, string $timeFormat)
+    {
+        $dayJsFormat = DateTimeFormatTranslator::toDayJS($timeFormat);
+        $markup = <<<MARKUP
+            <time
+                datetime="{$dateTime->format('c')}"
+                data-format="{$dayJsFormat}"
+                title="{$dateTime->format('F d, Y h:ia T')}"
+            >
+                {$dateTime->format($timeFormat)} UTC
+            </time>
+MARKUP;
+
+        return new Markup($markup, 'UTF-8');
+    }
+
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('human_time', [$this, 'buildTimeTag']),
+        ];
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -8,6 +8,12 @@
     "beberlei/doctrineextensions": {
         "version": "v1.2.2"
     },
+    "composer/semver": {
+        "version": "1.5.1"
+    },
+    "composer/xdebug-handler": {
+        "version": "1.4.2"
+    },
     "doctrine/annotations": {
         "version": "1.0",
         "recipe": {
@@ -90,6 +96,21 @@
     "egulias/email-validator": {
         "version": "2.1.7"
     },
+    "friendsofphp/php-cs-fixer": {
+        "version": "2.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "2.2",
+            "ref": "cc05ab6abf6894bddb9bbd6a252459010ebe040b"
+        },
+        "files": [
+            ".php_cs.dist"
+        ]
+    },
+    "kubawerlos/php-cs-fixer-custom-fixers": {
+        "version": "v2.3.0"
+    },
     "meyfa/php-svg": {
         "version": "v0.9.1"
     },
@@ -111,6 +132,9 @@
     "php": {
         "version": "7.2.5"
     },
+    "php-cs-fixer/diff": {
+        "version": "v1.3.0"
+    },
     "phpdocumentor/reflection-common": {
         "version": "1.0.1"
     },
@@ -119,6 +143,9 @@
     },
     "phpdocumentor/type-resolver": {
         "version": "0.4.0"
+    },
+    "phpstan/phpstan": {
+        "version": "0.12.37"
     },
     "psr/cache": {
         "version": "1.0.1"
@@ -338,6 +365,9 @@
             "tests/.gitignore"
         ]
     },
+    "symfony/polyfill-intl-grapheme": {
+        "version": "v1.18.1"
+    },
     "symfony/polyfill-intl-icu": {
         "version": "v1.11.0"
     },
@@ -421,6 +451,9 @@
     },
     "symfony/stopwatch": {
         "version": "v4.2.8"
+    },
+    "symfony/string": {
+        "version": "v5.1.3"
     },
     "symfony/swiftmailer-bundle": {
         "version": "2.5",

--- a/templates/_includes/navigation.html.twig
+++ b/templates/_includes/navigation.html.twig
@@ -53,6 +53,11 @@
                             Replays
                         </a>
                     </li>
+                    <li>
+                        <a href="{{ url('map_list') }}">
+                            Maps
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>

--- a/templates/map/index.html.twig
+++ b/templates/map/index.html.twig
@@ -1,0 +1,34 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Map List :: BZFlag Postgame{% endblock %}
+
+{% block body %}
+    <div class="container">
+        <h1 class="py-2">Map List</h1>
+
+        <div class="row">
+            {% for map in maps %}
+                <div class="col-md-4 mb-4">
+                    <article class="map-card">
+                        <div>
+                            {% if map.id in map_thumbnails | keys %}
+                                {{ map_thumbnails[map.id] | map_thumbnail }}
+                            {% else %}
+                                <p class="map-card__no-preview" aria-hidden="true">
+                                    <span>No map preview available</span>
+                                </p>
+                            {% endif %}
+                        </div>
+
+                        <div class="map-card__title">
+                            <h2 class="map-card__title__name">{{ map.name }}</h2>
+                            <p class="map-card__title__count">
+                                {{ (map_counts[map.id] ?? 0) | number_abbr(noun="match", content="played on this map") }}
+                            </p>
+                        </div>
+                    </article>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+{% endblock %}

--- a/templates/map/index.html.twig
+++ b/templates/map/index.html.twig
@@ -20,12 +20,18 @@
                             {% endif %}
                         </div>
 
-                        <div class="map-card__title">
+                        <a
+                            class="map-card__title"
+                            href="{{ url('map_show', {
+                                map: map.id,
+                                slug: map.slug,
+                            }) }}"
+                        >
                             <h2 class="map-card__title__name">{{ map.name }}</h2>
                             <p class="map-card__title__count">
                                 {{ (map_counts[map.id] ?? 0) | number_abbr(noun="match", content="played on this map") }}
                             </p>
-                        </div>
+                        </a>
                     </article>
                 </div>
             {% endfor %}

--- a/templates/map/show.html.twig
+++ b/templates/map/show.html.twig
@@ -1,5 +1,7 @@
 {% extends 'base.html.twig' %}
 
+{% from '_macros/versus-card.html.twig' import match_team_summary %}
+
 {% block title %}{{ map.name }} :: Map :: BZFlag Postgame{% endblock %}
 
 {% block body %}
@@ -8,7 +10,7 @@
             <div class="d-flex align-items-center">
                 <h1 class="mb-0">{{ map.name }}</h1>
                 <p class="mb-0 h5 flex-grow-1 text-right">
-                    {{ match_count | number_abbr(noun="matches") }}
+                    {{ match_count | number_abbr(noun="matches") }} matches
                 </p>
             </div>
         </div>
@@ -21,52 +23,56 @@
         </div>
 
         <section>
-            <h2 class="border-b py-2 mt-4 mb-3">Replays</h2>
+            <h2
+                class="border-b py-2 mt-4 mb-3"
+                id="recent-matches"
+            >
+                Recent Matches
+            </h2>
 
-            <table class="w-100">
-                <thead>
-                    <tr>
-                        <th>Date</th>
-                        <th class="w-100">Match</th>
-                        <th>Options</th>
-                    </tr>
-                </thead>
+            <div class="row">
+                {% set curr_year = 'now' | date('Y') %}
+                {% for replay in replays %}
+                    {% set replay_year = replay.startTime | date('Y', false) %}
+                    {% set date_fmt = (curr_year == replay_year) ? 'M d h:ia' : 'M d, Y h:ia' %}
 
-                <tbody>
-                    {% set curr_year = 'now' | date('Y') %}
-                    {% for replay in replays %}
-                        {% set replay_year = replay.startTime | date('Y', false) %}
-                        {% set date_fmt = (curr_year == replay_year) ? 'M d h:ia' : 'M d, Y h:ia' %}
+                    {# @var summary \App\Utility\QuickReplaySummary #}
+                    {% set summary = summaries[replay.id] %}
 
-                        {# @var summary \App\Utility\QuickReplaySummary #}
-                        {% set summary = summaries[replay.id] %}
+                    <div class="col-md-6 mb-4">
+                        <article class="background-translucent border-rounded p-3">
+                            <div class="text-center mb-3">
+                                <strong>
+                                    <small>
+                                        {{ replay.startTime | human_time(date_fmt) }}
+                                    </small>
+                                </strong>
+                            </div>
 
-                        <tr>
-                            <td>
-                                <span class="text-nowrap">
-                                    {{ replay.startTime | human_time(date_fmt) }}
-                                </span>
-                            </td>
-                            <td>
-                                {{ summary.winner | team_literal | title }} [{{ summary.winnerScore }}]
-                                vs.
-                                [{{ summary.loserScore }}] {{ summary.loser | team_literal | title }}
-                            </td>
-                            <td>
+                            <div>
+                                {{ match_team_summary(
+                                    summary.winner,
+                                    summary.winnerScore,
+                                    summary.loser,
+                                    summary.loserScore
+                                ) }}
+                            </div>
+
+                            <div class="text-center pt-3">
                                 <a
-                                    class="text-nowrap"
+                                    class="c-button c-button--skinny c-button--no-shadow"
                                     href="{{ url('replay_show', {
                                         id: replay.id,
                                         filename: replay.fileName,
                                     }) }}"
                                 >
-                                    View Replay
+                                    <small>View Replay</small>
                                 </a>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                            </div>
+                        </article>
+                    </div>
+                {% endfor %}
+            </div>
         </section>
     </div>
 {% endblock %}

--- a/templates/map/show.html.twig
+++ b/templates/map/show.html.twig
@@ -1,0 +1,72 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ map.name }} :: Map :: BZFlag Postgame{% endblock %}
+
+{% block body %}
+    <div class="container">
+        <div class="border-b py-2 mb-3">
+            <div class="d-flex align-items-center">
+                <h1 class="mb-0">{{ map.name }}</h1>
+                <p class="mb-0 h5 flex-grow-1 text-right">
+                    {{ match_count | number_abbr(noun="matches") }}
+                </p>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-4">
+                {{ thumbnail | map_thumbnail }}
+            </div>
+            <div class="col-md-8"></div>
+        </div>
+
+        <section>
+            <h2 class="border-b py-2 mt-4 mb-3">Replays</h2>
+
+            <table class="w-100">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th class="w-100">Match</th>
+                        <th>Options</th>
+                    </tr>
+                </thead>
+
+                <tbody>
+                    {% set curr_year = 'now' | date('Y') %}
+                    {% for replay in replays %}
+                        {% set replay_year = replay.startTime | date('Y', false) %}
+                        {% set date_fmt = (curr_year == replay_year) ? 'M d h:ia' : 'M d, Y h:ia' %}
+
+                        {# @var summary \App\Utility\QuickReplaySummary #}
+                        {% set summary = summaries[replay.id] %}
+
+                        <tr>
+                            <td>
+                                <span class="text-nowrap">
+                                    {{ replay.startTime | human_time(date_fmt) }}
+                                </span>
+                            </td>
+                            <td>
+                                {{ summary.winner | team_literal | title }} [{{ summary.winnerScore }}]
+                                vs.
+                                [{{ summary.loserScore }}] {{ summary.loser | team_literal | title }}
+                            </td>
+                            <td>
+                                <a
+                                    class="text-nowrap"
+                                    href="{{ url('replay_show', {
+                                        id: replay.id,
+                                        filename: replay.fileName,
+                                    }) }}"
+                                >
+                                    View Replay
+                                </a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </section>
+    </div>
+{% endblock %}

--- a/templates/map/show.html.twig
+++ b/templates/map/show.html.twig
@@ -6,7 +6,7 @@
 
 {% block body %}
     <div class="container">
-        <div class="border-b py-2 mb-3">
+        <div class="border-b py-2 mb-4">
             <div class="d-flex align-items-center">
                 <h1 class="mb-0">{{ map.name }}</h1>
                 <p class="mb-0 h5 flex-grow-1 text-right">
@@ -16,15 +16,17 @@
         </div>
 
         <div class="row">
-            <div class="col-md-4">
+            <div class="col-lg-4">
                 {{ thumbnail | map_thumbnail }}
             </div>
-            <div class="col-md-8"></div>
+            <div class="col-lg-8">
+
+            </div>
         </div>
 
         <section>
             <h2
-                class="border-b py-2 mt-4 mb-3"
+                class="border-b py-2 my-4"
                 id="recent-matches"
             >
                 Recent Matches
@@ -39,7 +41,7 @@
                     {# @var summary \App\Utility\QuickReplaySummary #}
                     {% set summary = summaries[replay.id] %}
 
-                    <div class="col-md-6 mb-4">
+                    <div class="col-lg-6 mb-4">
                         <article class="background-translucent border-rounded p-3">
                             <div class="text-center mb-3">
                                 <strong>

--- a/templates/map/show.html.twig
+++ b/templates/map/show.html.twig
@@ -1,5 +1,6 @@
 {% extends 'base.html.twig' %}
 
+{% from '_macros/charts.html.twig' import make_chart %}
 {% from '_macros/versus-card.html.twig' import match_team_summary %}
 
 {% block title %}{{ map.name }} :: Map :: BZFlag Postgame{% endblock %}
@@ -20,7 +21,7 @@
                 {{ thumbnail | map_thumbnail }}
             </div>
             <div class="col-lg-8">
-
+                {{ make_chart('match_activity', url('api_summary_replays', { map: map.id })) }}
             </div>
         </div>
 

--- a/templates/replay/index.html.twig
+++ b/templates/replay/index.html.twig
@@ -48,13 +48,7 @@
                                 <div class="replay-summary">
                                     <div class="replay-summary__timing small">
                                         <p>
-                                            <time
-                                                datetime="{{ replay.startTime | date('c', false) }}"
-                                                data-format="{{ time_fmt | dayjs_fmt }}"
-                                                title="{{ replay.startTime | date('F d, Y h:ia T', false) }}"
-                                            >
-                                                {{ replay.startTime | date(time_fmt, false) }} UTC
-                                            </time>
+                                            {{ replay.startTime | human_time(time_fmt) }}
                                         </p>
 
                                         <p>

--- a/templates/replay/show.html.twig
+++ b/templates/replay/show.html.twig
@@ -21,12 +21,14 @@
 
         <div class="row">
             <div class="col-lg-4">
-                <h2>Map Preview</h2>
+                <h2>
+                    Map {% if map and map.name %}- {{ map.name }}{% endif %}
+                </h2>
 
-                {% if thumbnail %}
+                {% if thumbnailURL %}
                     <img
                         class="map-thumbnail"
-                        src="{{ asset(thumbnail) }}"
+                        src="{{ asset(thumbnailURL) }}"
                         alt="A bird's-eye view of the map for this match"
                         aria-hidden="true"
                     />

--- a/templates/replay/show.html.twig
+++ b/templates/replay/show.html.twig
@@ -22,7 +22,13 @@
         <div class="row">
             <div class="col-lg-4">
                 <h2>
-                    Map {% if map and map.name %}- {{ map.name }}{% endif %}
+                    Map
+                    {% if map and map.name %}
+                        -
+                        <a href="{{ url('map_show', { map: map.id, slug: map.slug }) }}">
+                            {{ map.name }}
+                        </a>
+                    {% endif %}
                 </h2>
 
                 {% if thumbnail %}

--- a/templates/replay/show.html.twig
+++ b/templates/replay/show.html.twig
@@ -25,13 +25,8 @@
                     Map {% if map and map.name %}- {{ map.name }}{% endif %}
                 </h2>
 
-                {% if thumbnailURL %}
-                    <img
-                        class="map-thumbnail"
-                        src="{{ asset(thumbnailURL) }}"
-                        alt="A bird's-eye view of the map for this match"
-                        aria-hidden="true"
-                    />
+                {% if thumbnail %}
+                    {{ thumbnail | map_thumbnail }}
                 {% else %}
                     <p class="my-5 text-center"><em>No preview available</em></p>
                 {% endif %}

--- a/tests/Utility/DateTimeFormatTranslatorTest.php
+++ b/tests/Utility/DateTimeFormatTranslatorTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class DateTimeFormatTranslatorTest extends TestCase
 {
-    public static function dataProvider_dayJsFormats(): array
+    public static function dataProvider_testToDayJSConversion(): array
     {
         return [
             ['F j, Y, g:i a', 'MMMM D, YYYY, h:mm a'],
@@ -26,7 +26,7 @@ class DateTimeFormatTranslatorTest extends TestCase
     }
 
     /**
-     * @dataProvider dataProvider_dayJsFormats
+     * @dataProvider dataProvider_testToDayJSConversion
      *
      * @param $phpFormat
      * @param $expectedJS
@@ -35,7 +35,7 @@ class DateTimeFormatTranslatorTest extends TestCase
     {
         $translated = DateTimeFormatTranslator::toDayJS($phpFormat);
 
-        $this->assertEquals($expectedJS, $translated);
+        self::assertEquals($expectedJS, $translated);
     }
 
     public function testToDayJsConversionThrowsWarningWithUnsupportedCharacter(): void
@@ -45,6 +45,6 @@ class DateTimeFormatTranslatorTest extends TestCase
         $format = '\t\h\e jS \d\a\y';
         $translated = DateTimeFormatTranslator::toDayJS($format);
 
-        $this->assertEquals('[the] D [day]', $translated);
+        self::assertEquals('[the] D [day]', $translated);
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,9 +42,7 @@ Encore
     .enableVersioning(Encore.isProduction())
 
     // enables @babel/preset-env polyfills
-    .configureBabel(() => {}, {
-        useBuiltIns: false,
-    })
+    .configureBabel()
 
     // enables Sass/SCSS support
     .enableSassLoader(options => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4056,7 +4056,7 @@ loader-utils@1.2.3:
     emojis-list "^2.0.0"
     json5 "^1.0.1"
 
-loader-utils@^1.0.1, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -5553,15 +5553,15 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass-loader@^7.1.0:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.3.1.tgz#a5bf68a04bcea1c13ff842d747150f7ab7d0d23f"
-  integrity sha512-tuU7+zm0pTCynKYHpdqaPpe+MMTQ76I9TPZ7i4/5dZsigE350shQWe5EZNl5dBidM49TPET75tNqRbcsUZWeNA==
+sass-loader@^8.0.0:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.2.tgz#debecd8c3ce243c76454f2e8290482150380090d"
+  integrity sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==
   dependencies:
     clone-deep "^4.0.1"
-    loader-utils "^1.0.1"
-    neo-async "^2.5.0"
-    pify "^4.0.1"
+    loader-utils "^1.2.3"
+    neo-async "^2.6.1"
+    schema-utils "^2.6.1"
     semver "^6.3.0"
 
 sass@^1.20.1:
@@ -5585,7 +5585,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.0:
+schema-utils@^2.6.1, schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7"
   integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==


### PR DESCRIPTION
This PR introduces the following new commands. We can create map associates based on world hashes and any other logic via event subscribers. I have added a "Ducati" and "Ducati Mini" event subscriber as a fallback if we do not have hashes for static maps.

- `app:map:associate`
- `app:map:create`
- `app:map:list`

Basically, for static maps such as HiX (that don't change), we can associate hashes to it so new replays coming in with known hashes will have those associations.